### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-InfluxDB_UDP    KEYWORD1
-InfluxDB_Data   KEYWORD1
+InfluxDB_UDP	KEYWORD1
+InfluxDB_Data	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-addTag	    KEYWORD2
+addTag	KEYWORD2
 addField	KEYWORD2
-clear	    KEYWORD2
-toString    KEYWORD2
-write       KEYWORD2
+clear	KEYWORD2
+toString	KEYWORD2
+write	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords